### PR TITLE
Load log files using new method and not file annotation.

### DIFF
--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.env.data.OMEROGateway
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OMEROGateway.java
@@ -8337,4 +8337,30 @@ class OMEROGateway
         }
         return null;
      }
+
+    /**
+     * Loads the log files linked to the specified objects.
+     *
+     * @param ctx The security context.
+     * @param rootType The type of object to handle.
+     * @param rootIDs The collection of object's identifiers.
+     * @return See above.
+     * @throws DSOutOfServiceException If the connection is broken, or logged in
+     * @throws DSAccessException If an error occurred while trying to 
+     * retrieve data from OMERO service.
+     */
+    Map<Long, List<IObject>> loadLogFiles(SecurityContext ctx,
+            Class<?> rootType, List<Long> rootIDs)
+            throws DSOutOfServiceException, DSAccessException
+    {
+        Connector c = getConnector(ctx, true, false);
+        try {
+            IMetadataPrx service = c.getMetadataService();
+            return service.loadLogFiles(
+                            convertPojos(rootType).getName(), rootIDs);
+        } catch (Throwable t) {
+            handleException(t, "Cannot load log files for " + rootType+".");
+        }
+        return new HashMap();
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
@@ -2,10 +2,10 @@
  * org.openmicroscopy.shoola.env.data.OmeroMetadataService 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
- * 	This program is free software; you can redistribute it and/or modify
+ *  This program is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
  *  the Free Software Foundation; either version 2 of the License, or
  *  (at your option) any later version.
@@ -42,6 +42,7 @@ import omero.model.DetectorType;
 import omero.model.FilamentType;
 import omero.model.FilterType;
 import omero.model.Format;
+import omero.model.IObject;
 import omero.model.Illumination;
 import omero.model.Immersion;
 import omero.model.LaserMedium;
@@ -734,4 +735,18 @@ public interface OmeroMetadataService
 		List<String> nsExlcude)
 	throws DSOutOfServiceException, DSAccessException;
 
+	/**
+	 * Loads the log files linked to the specified objects.
+	 *
+	 * @param ctx The security context.
+	 * @param rootType The type of object to handle.
+	 * @param rootIDs The collection of object's identifiers.
+	 * @return See above.
+	 * @throws DSOutOfServiceException If the connection is broken, or logged in
+     * @throws DSAccessException If an error occurred while trying to 
+     * retrieve data from OMERO service.
+	 */
+	public Map<Long, List<IObject>> loadLogFiles(SecurityContext ctx,
+	        Class<?> rootType, List<Long> rootIDs)
+                throws DSOutOfServiceException, DSAccessException;
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataService.java
@@ -743,10 +743,10 @@ public interface OmeroMetadataService
 	 * @param rootIDs The collection of object's identifiers.
 	 * @return See above.
 	 * @throws DSOutOfServiceException If the connection is broken, or logged in
-     * @throws DSAccessException If an error occurred while trying to 
-     * retrieve data from OMERO service.
+	 * @throws DSAccessException If an error occurred while trying to 
+	 * retrieve data from OMERO service.
 	 */
 	public Map<Long, List<IObject>> loadLogFiles(SecurityContext ctx,
 	        Class<?> rootType, List<Long> rootIDs)
-                throws DSOutOfServiceException, DSAccessException;
+	                throws DSOutOfServiceException, DSAccessException;
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/OmeroMetadataServiceImpl.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.OmeroMetadataServiceImpl 
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -2192,4 +2192,17 @@ class OmeroMetadataServiceImpl
 		cmd.imageId = id;
 		return gateway.submit(Arrays.<Request>asList(cmd), ctx);
 	}
+
+    /**
+     * Implemented as specified by {@link OmeroDataService}.
+     * @see OmeroDataService#loadLogFiles(SecurityContext, Class, List)
+     */
+    public Map<Long, List<IObject>> loadLogFiles(SecurityContext ctx,
+            Class<?> rootType, List<Long> rootIDs)
+                    throws DSOutOfServiceException, DSAccessException
+   {
+        if (rootType == null || CollectionUtils.isEmpty(rootIDs))
+            throw new IllegalArgumentException("No node specified");
+        return gateway.loadLogFiles(ctx, rootType, rootIDs);
+    }
 }

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/FileUploader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/FileUploader.java
@@ -2,7 +2,7 @@
  * org.openmicroscopy.shoola.env.data.views.calls.FileUploader
  *
  *------------------------------------------------------------------------------
- *  Copyright (C) 2006-2013 University of Dundee. All rights reserved.
+ *  Copyright (C) 2006-2014 University of Dundee. All rights reserved.
  *
  *
  *  This program is free software; you can redistribute it and/or modify
@@ -25,7 +25,6 @@ package org.openmicroscopy.shoola.env.data.views.calls;
 //Java imports
 import java.io.File;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -33,8 +32,9 @@ import java.util.Map;
 import omero.model.IObject;
 import omero.model.OriginalFile;
 
-import org.apache.commons.collections.CollectionUtils;
+
 //Third-party libraries
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 

--- a/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/FileUploader.java
+++ b/components/insight/SRC/org/openmicroscopy/shoola/env/data/views/calls/FileUploader.java
@@ -30,6 +30,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import omero.model.IObject;
+import omero.model.OriginalFile;
+
+import org.apache.commons.collections.CollectionUtils;
 //Third-party libraries
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -126,25 +130,26 @@ public class FileUploader
 						object.getSecurityContext());
 				try {
 					if (object.isRetrieveFromAnnotation()) {
-						Map<Long, Collection<AnnotationData>> map =
-						svc.loadAnnotations(ctx, FilesetData.class,
-							Arrays.asList(id), FileAnnotationData.class,
-							Arrays.asList(FileAnnotationData.LOG_FILE_NS),
-							null);
+						final Map<Long, List<IObject>> map =
+						svc.loadLogFiles(ctx, FilesetData.class,
+							Arrays.asList(id));
 						if (map.size() == 0) id = -1;
 						else {
-							Collection<AnnotationData> l = map.get(id);
+							List<IObject> l = map.get(id);
 							id = -1; //reset
-							Iterator<AnnotationData> k = l.iterator();
-							AnnotationData data;
-							while (k.hasNext()) {
-								data = k.next();
-								if (FileAnnotationData.LOG_FILE_NS.equals(
-										data.getNameSpace())) {
-									id = ((FileAnnotationData) data).getFileID();
-									break;
-								}
+							if (CollectionUtils.isNotEmpty(l)) {
+							    Iterator<IObject> k = l.iterator();
+	                            IObject data;
+	                            while (k.hasNext()) {
+	                                data = k.next();
+	                                if (data instanceof OriginalFile) {
+	                                    id = ((OriginalFile) 
+	                                            data).getId().getValue();
+	                                    break;
+	                                }
+	                            }
 							}
+							
 						}
 					}
 				} catch (Exception ex) {


### PR DESCRIPTION
This method will only be used if the log file ID was not correctly returned by the import event.
