### PR TITLE
Add cascading for map types

### DIFF
--- a/components/dsl/resources/ome/dsl/object.vm
+++ b/components/dsl/resources/ome/dsl/object.vm
@@ -406,6 +406,7 @@ implements java.io.Serializable, IObject
     @javax.persistence.Column(name="${prop.name}", nullable=false)
     @javax.persistence.CollectionTable(name="${type.tableName()}_${prop.name}",
         joinColumns = @javax.persistence.JoinColumn(name="${type.tableName()}_id"))
+    @org.hibernate.annotations.Cascade({${cascadeHibCollection}})
     public java.util.Map<String, String> get${prop.nameCapped}() {
         return this.${prop.name};
     }


### PR DESCRIPTION
Removing UploadJob.versionInfo from spec.xml caused
foreign-key constraints in the breaking daily jobs.
This change should hopefully allow deletes and the
like to properly propagate to the map collection.
