### PR TITLE
Test for obj2

### DIFF
--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -21,6 +21,7 @@
 
 
 import pytest
+import omero
 
 from test.integration.clitest.cli import CLITest
 from omero_model_NamespaceI import NamespaceI
@@ -44,6 +45,13 @@ class TestObj(CLITest):
     def go(self):
         self.cli.invoke(self.args, strict=True)
         return self.cli.get("tx.state")
+
+    def create_line(self):
+        roi = omero.model.RoiI()
+        line = omero.model.LineI()
+        roi.addShape(line)
+        line = self.update.saveAndReturnObject(line)
+        return line.id.val
 
     def create_script(self):
         path = create_path()
@@ -163,6 +171,16 @@ class TestObj(CLITest):
         AffineTransform = state.get_row(0)
         aid = AffineTransform.split(":")[1]
         assert AffineTransform == "AffineTransform:%s" % aid
+        y2 = 40
+        lid = self.create_line()
+        self.args = self.login_args() + [
+            "obj", "update", "Line:%s" % lid,
+            "x1=10", "x2=20", "y1=30", "y2=%s" % y2]
+        state = self.go()
+        self.args = self.login_args() + [
+            "obj", "get", "Line:%s" % lid]
+        state = self.go()
+        assert "y2=%s" % y2 in state.get_row(0)
 
     def test_new_and_get_obj(self):
         pname = "foo"

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -154,6 +154,16 @@ class TestObj(CLITest):
             with pytest.raises(Exception):
                 self.go()
 
+    def test_argument_with_letters_and_numbers(self):
+        self.args = self.login_args() + ["obj", "new", "AffineTransform"]
+        for matrix_pos in ["00", "10", "01", "11", "02", "12"]:
+            argument = "a%s=1" % matrix_pos
+            self.args.append(argument)
+        state = self.go()
+        AffineTransform = state.get_row(0)
+        aid = AffineTransform.split(":")[1]
+        assert AffineTransform == "AffineTransform:%s" % aid
+
     def test_new_and_get_obj(self):
         pname = "foo"
         dname = "bar"

--- a/components/tools/OmeroPy/test/integration/clitest/test_obj.py
+++ b/components/tools/OmeroPy/test/integration/clitest/test_obj.py
@@ -147,6 +147,13 @@ class TestObj(CLITest):
         state = self.go()
         assert state.get_row(0) == desc
 
+    def test_fail_leading_numbers_argument(self):
+        for argument in ("123name", "123"):
+            self.args = self.login_args() + [
+                "obj", "new", "Project", "%s=foo" % argument]
+            with pytest.raises(Exception):
+                self.go()
+
     def test_new_and_get_obj(self):
         pname = "foo"
         dname = "bar"


### PR DESCRIPTION
This replaces https://github.com/mtbc/openmicroscopy/pull/13 which was closed in order to solve syncing with @mtbc 's branch problems.

See https://github.com/openmicroscopy/openmicroscopy/pull/4672#issuecomment-220339279 and https://github.com/openmicroscopy/openmicroscopy/pull/4672#issuecomment-221810038. These are the discussed tests for making sure the arguments such as `arg1, arg2`  of following example `bin/omero obj ....arg1=x arg2=y...`  can:
- be a character followed by number (done here for 2 cases, AffineTransform and Line roi
- be a character (already covered in existing tests, e.g. [name of dataset](https://github.com/openmicroscopy/openmicroscopy/blob/develop/components/tools/OmeroPy/test/integration/clitest/test_obj.py#L67), not dealt with in this PR
- cannot be a number followed by letters, done in https://github.com/mtbc/openmicroscopy/commit/d95094e5af23a506d293c0b0d0a7018e5b64b91f in `test_fail_leading_numbers_argument`
- cannot be a number, also done in https://github.com/mtbc/openmicroscopy/commit/d95094e5af23a506d293c0b0d0a7018e5b64b91f here in `test_fail_leading_numbers_argument`

I did not do any iterations and post-checks except:
- checking that the Line was updated as intended using the `obj get...` command and comparing the `y2` value, verifying that the arguments of the preceding `obj update....` were passed successfully
- checking that the AffineTransform `obj new...` output contains just `AffineTransorm:ID`, i.e. the action did not fail and thus the arguments were passed succesfully
